### PR TITLE
Refactor: consolidate formatting helpers

### DIFF
--- a/src/__tests__/formatters/cliResults.test.ts
+++ b/src/__tests__/formatters/cliResults.test.ts
@@ -1,0 +1,53 @@
+import { formatCliResults } from '../../formatters/cliResults.js';
+
+const baseEvaluation = {
+  score: 0.5,
+  properties: {
+    threshold: 0.1,
+  },
+};
+
+describe('cli result formatter', () => {
+  it('signals success when all evaluations pass', () => {
+    const { lines, hasFailures } = formatCliResults([
+      {
+        success: true,
+        ruleId: 'quality',
+        configName: 'src',
+        evaluation: baseEvaluation,
+      },
+    ]);
+
+    expect(hasFailures).toBe(false);
+    expect(lines[0]).toBe('\n📊 Evaluation Results (1 total):');
+    expect(lines).toContain('🎉 All evaluations passed!');
+    expect(lines).toContain('  ✅ PASS quality: 0.500 (threshold: 0.1)');
+  });
+
+  it('signals failure details when an evaluation fails', () => {
+    const { lines, hasFailures } = formatCliResults([
+      {
+        success: true,
+        ruleId: 'quality',
+        configName: 'src',
+        evaluation: baseEvaluation,
+      },
+      {
+        success: false,
+        ruleId: 'coverage',
+        configName: 'tests',
+        evaluation: {
+          score: 0.2,
+          properties: {
+            threshold: 0.1,
+          },
+        },
+      },
+    ]);
+
+    expect(hasFailures).toBe(true);
+    expect(lines).toContain('💥 Some evaluations failed.');
+    expect(lines).toContain('\n❌ Failed evaluations (1):');
+    expect(lines).toContain('  - tests.coverage: 0.200');
+  });
+});

--- a/src/__tests__/formatters/configMessages.test.ts
+++ b/src/__tests__/formatters/configMessages.test.ts
@@ -1,0 +1,26 @@
+import {
+  formatConfigErrors,
+  formatConfigWarnings,
+} from '../../formatters/configMessages.js';
+
+describe('config message formatters', () => {
+  it('prefixes errors with config context', () => {
+    expect(
+      formatConfigErrors('src', 0, ['Missing files', 'Invalid rule'])
+    ).toEqual([
+      'Config 1 (src): Missing files',
+      'Config 1 (src): Invalid rule',
+    ]);
+  });
+
+  it('falls back to unnamed config label', () => {
+    expect(formatConfigWarnings(undefined, 1, ['No rules'])).toEqual([
+      'Config 2 (unnamed): No rules',
+    ]);
+  });
+
+  it('returns empty arrays when no messages exist', () => {
+    expect(formatConfigErrors('src', 0, [])).toEqual([]);
+    expect(formatConfigWarnings('src', 0, [])).toEqual([]);
+  });
+});

--- a/src/__tests__/formatters/payload.test.ts
+++ b/src/__tests__/formatters/payload.test.ts
@@ -1,0 +1,45 @@
+import { formatPrompt, formatResponse } from '../../formatters/payload.js';
+import { GitFileStatus } from '../../types.js';
+
+describe('payload formatters', () => {
+  const baseFile = {
+    path: 'src/example.ts',
+    status: GitFileStatus.MODIFIED,
+    beforeContent: 'console.log(1);',
+    afterContent: 'console.log(2);',
+    diff: 'diff --git a/src/example.ts b/src/example.ts',
+  };
+
+  it('builds prompts with intent and before-content sections', () => {
+    const prompt = formatPrompt('Implement feature', [baseFile]);
+
+    expect(prompt).toBe(
+      [
+        'Implement feature',
+        'File: `src/example.ts`\n```\nconsole.log(1);\n```',
+      ].join('\n---\n')
+    );
+  });
+
+  it('omits before-content when none available', () => {
+    const prompt = formatPrompt('Intent only', [
+      { ...baseFile, beforeContent: undefined },
+    ]);
+
+    expect(prompt).toBe('Intent only');
+  });
+
+  it('joins diffs into the response payload', () => {
+    const response = formatResponse([
+      baseFile,
+      { ...baseFile, path: 'src/second.ts', diff: 'diff --git second' },
+    ]);
+
+    expect(response).toBe(
+      [
+        'diff --git a/src/example.ts b/src/example.ts',
+        'diff --git second',
+      ].join('\n---\n')
+    );
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,10 +3,10 @@
 import { Command } from 'commander';
 
 import { MandolineCI } from './core.js';
-import { resolveGitReferences } from './git.js';
 import { formatCliResults } from './formatters/cliResults.js';
-import { getPackageVersion } from './utils.js';
+import { resolveGitReferences } from './git.js';
 import type { EvalResult } from './types.js';
+import { getPackageVersion } from './utils.js';
 
 function displayResults(results: EvalResult[]): void {
   const { lines, hasFailures } = formatCliResults(results);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,73 +2,20 @@
 
 import { Command } from 'commander';
 
-import { DEFAULT_THRESHOLD } from './constants.js';
 import { MandolineCI } from './core.js';
 import { resolveGitReferences } from './git.js';
+import { formatCliResults } from './formatters/cliResults.js';
 import { getPackageVersion } from './utils.js';
+import type { EvalResult } from './types.js';
 
-function displayResults(results: any[]): void {
-  // Display results
-  console.log(`\n📊 Evaluation Results (${results.length} total):`);
-  console.log('─'.repeat(60));
+function displayResults(results: EvalResult[]): void {
+  const { lines, hasFailures } = formatCliResults(results);
 
-  const configGroups = groupBy(results, (r) => r.configName);
-  let overallPassed = true;
-
-  for (const [configName, configResults] of Object.entries(configGroups)) {
-    console.log(`\n🔧 Configuration: ${configName}`);
-
-    const configPassed = configResults.every((r) => r.success);
-    overallPassed = overallPassed && configPassed;
-
-    for (const result of configResults) {
-      const status = result.success ? '✅ PASS' : '❌ FAIL';
-      const score = result.evaluation.score.toFixed(3);
-      const threshold =
-        result.evaluation.properties?.threshold ?? DEFAULT_THRESHOLD;
-
-      console.log(
-        `  ${status} ${result.ruleId}: ${score} (threshold: ${threshold})`
-      );
-    }
+  for (const line of lines) {
+    console.log(line);
   }
 
-  console.log('\n' + '─'.repeat(60));
-
-  if (overallPassed) {
-    console.log('🎉 All evaluations passed!');
-    process.exit(0);
-  } else {
-    console.log('💥 Some evaluations failed.');
-
-    // Show summary of failures
-    const failures = results.filter((r) => !r.success);
-    console.log(`\n❌ Failed evaluations (${failures.length}):`);
-    for (const failure of failures) {
-      console.log(
-        `  - ${failure.configName}.${
-          failure.ruleId
-        }: ${failure.evaluation.score.toFixed(3)}`
-      );
-    }
-
-    process.exit(1);
-  }
-}
-
-function groupBy<T>(
-  array: T[],
-  keyFn: (item: T) => string
-): Record<string, T[]> {
-  return array.reduce(
-    (groups, item) => {
-      const key = keyFn(item);
-      groups[key] = groups[key] || [];
-      groups[key].push(item);
-      return groups;
-    },
-    {} as Record<string, T[]>
-  );
+  process.exit(hasFailures ? 1 : 0);
 }
 
 // CLI Setup & Program Definition

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,12 +5,15 @@ import { access } from 'fs/promises';
 
 import { CONFIG_FILENAMES, DEFAULT_THRESHOLD } from './constants.js';
 import {
+  formatConfigErrors,
+  formatConfigWarnings,
+} from './formatters/configMessages.js';
+import { formatError } from './formatters/errors.js';
+import {
   ConfigDiscoveryOptions,
   EvalConfig,
   ValidationResult,
 } from './types.js';
-import { formatError } from './formatters/errors.js';
-import { formatConfigErrors, formatConfigWarnings } from './formatters/configMessages.js';
 import { isValidUUID } from './utils.js';
 
 export async function discoverConfig(
@@ -135,9 +138,7 @@ export function validateConfigs(configs: EvalConfig[]): ValidationResult {
     const result = validateConfig(config);
 
     // Add context to errors and warnings
-    allErrors.push(
-      ...formatConfigErrors(config.name, index, result.errors)
-    );
+    allErrors.push(...formatConfigErrors(config.name, index, result.errors));
     allWarnings.push(
       ...formatConfigWarnings(config.name, index, result.warnings)
     );

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,9 @@ import {
   EvalConfig,
   ValidationResult,
 } from './types.js';
-import { formatError, isValidUUID } from './utils.js';
+import { formatError } from './formatters/errors.js';
+import { formatConfigErrors, formatConfigWarnings } from './formatters/configMessages.js';
+import { isValidUUID } from './utils.js';
 
 export async function discoverConfig(
   options: ConfigDiscoveryOptions = {}
@@ -133,15 +135,11 @@ export function validateConfigs(configs: EvalConfig[]): ValidationResult {
     const result = validateConfig(config);
 
     // Add context to errors and warnings
-    result.errors.forEach((error) =>
-      allErrors.push(
-        `Config ${index + 1} (${config.name || 'unnamed'}): ${error}`
-      )
+    allErrors.push(
+      ...formatConfigErrors(config.name, index, result.errors)
     );
-    result.warnings.forEach((warning) =>
-      allWarnings.push(
-        `Config ${index + 1} (${config.name || 'unnamed'}): ${warning}`
-      )
+    allWarnings.push(
+      ...formatConfigWarnings(config.name, index, result.warnings)
     );
 
     // Check for duplicate names

--- a/src/core.ts
+++ b/src/core.ts
@@ -7,6 +7,7 @@ import {
   validateConfigs,
 } from './config.js';
 import { getEnvironmentContext } from './context.js';
+import { formatPrompt, formatResponse } from './formatters/payload.js';
 import {
   analyzeGitDiff,
   validateGitRefs,
@@ -212,24 +213,8 @@ export async function executeEvaluations(
     for (const [ruleId, rule] of Object.entries(config.rules)) {
       const threshold = rule.threshold ?? getDefaultThreshold();
 
-      const beforeSections = filteredFiles
-        .map((file) =>
-          file.beforeContent
-            ? `File: \`${file.path}\`\n\`\`\`\n${file.beforeContent}\n\`\`\``
-            : null
-        )
-        .filter((value): value is string => Boolean(value));
-
-      const promptSegments = [intentSource.content];
-      if (beforeSections.length > 0) {
-        promptSegments.push(beforeSections.join('\n---\n'));
-      }
-      const prompt = promptSegments.join('\n---\n');
-
-      const response = filteredFiles
-        .map((file) => file.diff)
-        .filter(Boolean)
-        .join('\n---\n');
+      const prompt = formatPrompt(intentSource.content, filteredFiles);
+      const response = formatResponse(filteredFiles);
 
       const evaluation = await client.createEvaluation({
         metricId: rule.metricId,

--- a/src/formatters/cliResults.ts
+++ b/src/formatters/cliResults.ts
@@ -1,0 +1,73 @@
+import { DEFAULT_THRESHOLD } from '../constants.js';
+import type { EvalResult } from '../types.js';
+
+const SEPARATOR = '─'.repeat(60);
+
+interface CliResults {
+  lines: string[];
+  hasFailures: boolean;
+}
+
+function groupByConfig(
+  results: EvalResult[]
+): Record<string, EvalResult[]> {
+  return results.reduce<Record<string, EvalResult[]>>((acc, result) => {
+    const key = result.configName;
+    if (!acc[key]) {
+      acc[key] = [];
+    }
+    acc[key].push(result);
+    return acc;
+  }, {});
+}
+
+export function formatCliResults(results: EvalResult[]): CliResults {
+  const lines: string[] = [
+    `\n📊 Evaluation Results (${results.length} total):`,
+    SEPARATOR,
+  ];
+
+  const groupedResults = groupByConfig(results);
+  let hasFailures = false;
+
+  for (const [configName, configResults] of Object.entries(groupedResults)) {
+    lines.push(`\n🔧 Configuration: ${configName}`);
+
+    if (!configResults.every((result) => result.success)) {
+      hasFailures = true;
+    }
+
+    for (const result of configResults) {
+      const status = result.success ? '✅ PASS' : '❌ FAIL';
+      const score = result.evaluation.score.toFixed(3);
+      const threshold =
+        result.evaluation.properties?.threshold ?? DEFAULT_THRESHOLD;
+
+      lines.push(
+        `  ${status} ${result.ruleId}: ${score} (threshold: ${threshold})`
+      );
+    }
+  }
+
+  lines.push(`\n${SEPARATOR}`);
+
+  if (!hasFailures) {
+    lines.push('🎉 All evaluations passed!');
+    return { lines, hasFailures };
+  }
+
+  lines.push('💥 Some evaluations failed.');
+
+  const failures = results.filter((result) => !result.success);
+  lines.push(`\n❌ Failed evaluations (${failures.length}):`);
+
+  for (const failure of failures) {
+    lines.push(
+      `  - ${failure.configName}.${failure.ruleId}: ${failure.evaluation.score.toFixed(
+        3
+      )}`
+    );
+  }
+
+  return { lines, hasFailures };
+}

--- a/src/formatters/cliResults.ts
+++ b/src/formatters/cliResults.ts
@@ -8,9 +8,7 @@ interface CliResults {
   hasFailures: boolean;
 }
 
-function groupByConfig(
-  results: EvalResult[]
-): Record<string, EvalResult[]> {
+function groupByConfig(results: EvalResult[]): Record<string, EvalResult[]> {
   return results.reduce<Record<string, EvalResult[]>>((acc, result) => {
     const key = result.configName;
     if (!acc[key]) {

--- a/src/formatters/configMessages.ts
+++ b/src/formatters/configMessages.ts
@@ -1,0 +1,29 @@
+function getConfigLabel(name: string | undefined, index: number): string {
+  return `Config ${index + 1} (${name || 'unnamed'})`;
+}
+
+export function formatConfigErrors(
+  name: string | undefined,
+  index: number,
+  errors: string[]
+): string[] {
+  if (errors.length === 0) {
+    return [];
+  }
+
+  const label = getConfigLabel(name, index);
+  return errors.map((error) => `${label}: ${error}`);
+}
+
+export function formatConfigWarnings(
+  name: string | undefined,
+  index: number,
+  warnings: string[]
+): string[] {
+  if (warnings.length === 0) {
+    return [];
+  }
+
+  const label = getConfigLabel(name, index);
+  return warnings.map((warning) => `${label}: ${warning}`);
+}

--- a/src/formatters/errors.ts
+++ b/src/formatters/errors.ts
@@ -1,0 +1,6 @@
+/**
+ * Format an error with additional context for human-readable logging.
+ */
+export function formatError(error: unknown, context: string): string {
+  return `${context}: ${error instanceof Error ? error.message : String(error)}`;
+}

--- a/src/formatters/payload.ts
+++ b/src/formatters/payload.ts
@@ -1,0 +1,32 @@
+import type { GitFileChange } from '../types.js';
+
+const SECTION_DELIMITER = '\n---\n';
+
+function formatBeforeSection(file: GitFileChange): string | null {
+  if (!file.beforeContent) {
+    return null;
+  }
+
+  return `File: \`${file.path}\`\n\`\`\`\n${file.beforeContent}\n\`\`\``;
+}
+
+export function formatPrompt(intent: string, files: GitFileChange[]): string {
+  const beforeSections = files
+    .map(formatBeforeSection)
+    .filter((value): value is string => Boolean(value));
+
+  const segments = [intent];
+
+  if (beforeSections.length > 0) {
+    segments.push(beforeSections.join(SECTION_DELIMITER));
+  }
+
+  return segments.join(SECTION_DELIMITER);
+}
+
+export function formatResponse(files: GitFileChange[]): string {
+  return files
+    .map((file) => file.diff)
+    .filter((diff): diff is string => Boolean(diff))
+    .join(SECTION_DELIMITER);
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -12,7 +12,8 @@ import {
   GitFileStatus,
   ReferenceSelection,
 } from './types.js';
-import { createGit, formatError } from './utils.js';
+import { formatError } from './formatters/errors.js';
+import { createGit } from './utils.js';
 
 export async function analyzeGitDiff(
   base: string,

--- a/src/git.ts
+++ b/src/git.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_HEAD_BRANCH,
   EMPTY_TREE_HASH,
 } from './constants.js';
+import { formatError } from './formatters/errors.js';
 import {
   GitContext,
   GitDiffResult,
@@ -12,7 +13,6 @@ import {
   GitFileStatus,
   ReferenceSelection,
 } from './types.js';
-import { formatError } from './formatters/errors.js';
 import { createGit } from './utils.js';
 
 export async function analyzeGitDiff(

--- a/src/intent.ts
+++ b/src/intent.ts
@@ -2,7 +2,8 @@ import { readFile } from 'fs/promises';
 
 import { EMPTY_TREE_HASH } from './constants.js';
 import { IntentSource } from './types.js';
-import { createGit, formatError } from './utils.js';
+import { formatError } from './formatters/errors.js';
+import { createGit } from './utils.js';
 
 export async function extractIntent(
   base: string,

--- a/src/intent.ts
+++ b/src/intent.ts
@@ -1,8 +1,8 @@
 import { readFile } from 'fs/promises';
 
 import { EMPTY_TREE_HASH } from './constants.js';
-import { IntentSource } from './types.js';
 import { formatError } from './formatters/errors.js';
+import { IntentSource } from './types.js';
 import { createGit } from './utils.js';
 
 export async function extractIntent(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,13 +12,6 @@ export function createGit(workingDir?: string): SimpleGit {
 }
 
 /**
- * Utility for consistent error formatting across the application
- */
-export function formatError(error: unknown, context: string): string {
-  return `${context}: ${error instanceof Error ? error.message : String(error)}`;
-}
-
-/**
  * Safely read a file, returning null if it doesn't exist or can't be read
  */
 export function safeReadFile(path: string): string | null {


### PR DESCRIPTION
## Summary
- consolidate presentation helpers into dedicated formatter modules
- update CLI/core/config/git/intent to use the formatters without changing behavior
- add formatter-focused Jest coverage for CLI output, payload assembly, and config messaging