### PR TITLE
Support minimize metric objectives

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,18 @@ export default [
         metricId: '4cb434d4-c012-48ac-9a40-19b92d73450e',
         threshold: 0.1,
       },
+      'error-regressions': {
+        metricId: 'c7efb63f-3b6d-4b32-9dc6-04bddc8ebabc',
+        threshold: 0.2,
+        scoreObjective: 'minimize', // lower score indicates fewer regressions
+      },
       // and so on...
     },
   },
 ];
 ```
+
+Omit `scoreObjective` to use the default `'maximize'` behavior (higher scores pass). Set it to `'minimize'` when Mandoline should treat lower scores as better.
 
 See this repo's [configuration](https://github.com/mandoline-ai/mandoline-ci/blob/main/mandoline-ci.config.mjs) for a complete example.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mandoline-ci",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mandoline-ci",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^11.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2029,9 +2029,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
-      "integrity": "sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.7.tgz",
+      "integrity": "sha512-bxxN2M3a4d1CRoQC//IqsR5XrLh0IJ8TCv2x6Y9N0nckNz/rTjZB3//GGscZziZOxmjP55rzxg/ze7usFI9FqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2146,9 +2146,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001743",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
-      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
+      "version": "1.0.30001745",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001745.tgz",
+      "integrity": "sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==",
       "dev": true,
       "funding": [
         {
@@ -2428,9 +2428,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.223",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.223.tgz",
-      "integrity": "sha512-qKm55ic6nbEmagFlTFczML33rF90aU+WtrJ9MdTCThrcvDNdUHN4p6QfVN78U06ZmguqXIyMPyYhw2TrbDUwPQ==",
+      "version": "1.5.224",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.224.tgz",
+      "integrity": "sha512-kWAoUu/bwzvnhpdZSIc6KUyvkI1rbRXMT0Eq8pKReyOyaPZcctMli+EgvcN1PAvwVc7Tdo4Fxi2PsLNDU05mdg==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mandoline-ci",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Integrate custom code evals into CI pipelines using the Mandoline API.",
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -48,6 +48,24 @@ describe('config validation', () => {
       );
     });
 
+    it('should fail for invalid scoreObjective', () => {
+      const config = {
+        ...validConfig,
+        rules: {
+          'test-rule': {
+            name: 'test-rule',
+            metricId: '12345678-1234-5678-9012-123456789012',
+            scoreObjective: 'optimize',
+          },
+        },
+      } as unknown as EvalConfig;
+      const result = validateConfig(config);
+      expect(result.success).toBe(false);
+      expect(result.errors).toContain(
+        'Rule "test-rule" scoreObjective must be either "maximize" or "minimize"'
+      );
+    });
+
     it('should fail for threshold outside range', () => {
       const config = {
         ...validConfig,

--- a/src/__tests__/formatters/cliResults.test.ts
+++ b/src/__tests__/formatters/cliResults.test.ts
@@ -21,7 +21,9 @@ describe('cli result formatter', () => {
     expect(hasFailures).toBe(false);
     expect(lines[0]).toBe('\n📊 Evaluation Results (1 total):');
     expect(lines).toContain('🎉 All evaluations passed!');
-    expect(lines).toContain('  ✅ PASS quality: 0.500 (threshold: 0.1)');
+    expect(lines).toContain(
+      '  ✅ PASS quality: score 0.500 >= threshold 0.100 (maximize)'
+    );
   });
 
   it('signals failure details when an evaluation fails', () => {
@@ -49,5 +51,28 @@ describe('cli result formatter', () => {
     expect(lines).toContain('💥 Some evaluations failed.');
     expect(lines).toContain('\n❌ Failed evaluations (1):');
     expect(lines).toContain('  - tests.coverage: 0.200');
+  });
+
+  it('renders comparator for minimize objective', () => {
+    const { lines } = formatCliResults([
+      {
+        success: true,
+        ruleId: 'regression',
+        configName: 'src',
+        evaluation: {
+          score: 0.12,
+          properties: {
+            threshold: 0.3,
+            scoreObjective: 'minimize',
+          },
+        },
+        scoreObjective: 'minimize',
+        threshold: 0.3,
+      },
+    ]);
+
+    expect(lines).toContain(
+      '  ✅ PASS regression: score 0.120 <= threshold 0.300 (minimize)'
+    );
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,11 @@ import { pathToFileURL } from 'url';
 
 import { access } from 'fs/promises';
 
-import { CONFIG_FILENAMES, DEFAULT_THRESHOLD } from './constants.js';
+import {
+  CONFIG_FILENAMES,
+  DEFAULT_SCORE_OBJECTIVE,
+  DEFAULT_THRESHOLD,
+} from './constants.js';
 import {
   formatConfigErrors,
   formatConfigWarnings,
@@ -12,6 +16,7 @@ import { formatError } from './formatters/errors.js';
 import {
   ConfigDiscoveryOptions,
   EvalConfig,
+  RuleConfig,
   ValidationResult,
 } from './types.js';
 import { isValidUUID } from './utils.js';
@@ -115,6 +120,16 @@ export function validateConfig(config: EvalConfig): ValidationResult {
       ) {
         errors.push(`Rule "${ruleId}" threshold must be between -1 and 1`);
       }
+
+      if (
+        rule.scoreObjective !== undefined &&
+        rule.scoreObjective !== 'maximize' &&
+        rule.scoreObjective !== 'minimize'
+      ) {
+        errors.push(
+          `Rule "${ruleId}" scoreObjective must be either "maximize" or "minimize"`
+        );
+      }
     }
 
     if (Object.keys(config.rules).length === 0) {
@@ -166,4 +181,14 @@ export function validateConfigs(configs: EvalConfig[]): ValidationResult {
 
 export function getDefaultThreshold(): number {
   return DEFAULT_THRESHOLD;
+}
+
+export function resolveRuleEvaluationSettings(rule: RuleConfig): {
+  threshold: number;
+  scoreObjective: 'maximize' | 'minimize';
+} {
+  return {
+    threshold: rule.threshold ?? getDefaultThreshold(),
+    scoreObjective: rule.scoreObjective ?? DEFAULT_SCORE_OBJECTIVE,
+  };
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@
 export const DEFAULT_THRESHOLD = -0.333;
 export const DEFAULT_BASE_BRANCH = 'main';
 export const DEFAULT_HEAD_BRANCH = 'HEAD';
+export const DEFAULT_SCORE_OBJECTIVE = 'maximize';
 
 // Git's empty tree hash - used for comparing against initial commits or shallow clones
 export const EMPTY_TREE_HASH = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';

--- a/src/formatters/cliResults.ts
+++ b/src/formatters/cliResults.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_THRESHOLD } from '../constants.js';
+import { DEFAULT_SCORE_OBJECTIVE, DEFAULT_THRESHOLD } from '../constants.js';
 import type { EvalResult } from '../types.js';
 
 const SEPARATOR = '─'.repeat(60);
@@ -38,11 +38,20 @@ export function formatCliResults(results: EvalResult[]): CliResults {
     for (const result of configResults) {
       const status = result.success ? '✅ PASS' : '❌ FAIL';
       const score = result.evaluation.score.toFixed(3);
+      const thresholdValue =
+        result.threshold ?? result.evaluation.properties?.threshold;
       const threshold =
-        result.evaluation.properties?.threshold ?? DEFAULT_THRESHOLD;
+        typeof thresholdValue === 'number'
+          ? thresholdValue.toFixed(3)
+          : DEFAULT_THRESHOLD.toFixed(3);
+      const objective =
+        result.scoreObjective ??
+        result.evaluation.properties?.scoreObjective ??
+        DEFAULT_SCORE_OBJECTIVE;
+      const comparator = objective === 'minimize' ? '<=' : '>=';
 
       lines.push(
-        `  ${status} ${result.ruleId}: ${score} (threshold: ${threshold})`
+        `  ${status} ${result.ruleId}: score ${score} ${comparator} threshold ${threshold} (${objective})`
       );
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,10 @@ export interface RuleConfig extends BaseConfig {
   metricId: UUID;
   threshold?: number; // default: DEFAULT_THRESHOLD
   weight?: number; // For future weighted scoring
+  /**
+   * Determines whether the metric should be maximized or minimized. Defaults to 'maximize'.
+   */
+  scoreObjective?: 'maximize' | 'minimize';
 }
 
 export interface EvaluateDiffOptions {
@@ -51,6 +55,7 @@ export interface EvalResult extends BaseResult {
   configName: string;
   score?: number;
   threshold?: number;
+  scoreObjective?: 'maximize' | 'minimize';
 }
 
 export type LogFunction = (message: string) => void;


### PR DESCRIPTION
## Summary
- allow configs to choose scoreObjective 'maximize' or 'minimize' and validate values
- adjust evaluation logic and CLI output so minimized metrics compare with <= and show objective labels
- document usage, update README/AGENTS, and bump npm version to 0.2.3

## Testing
- npm test -- --watchman=false