### PR TITLE
Refresh CLI tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mandoline CI
 
-Integrate custom code evals into CI pipelines using the [Mandoline API](http://mandoline.ai).
+Extend CI with Custom Code Evals using the [Mandoline API](http://mandoline.ai).
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mandoline-ci",
   "version": "0.2.3",
-  "description": "Integrate custom code evals into CI pipelines using the Mandoline API.",
+  "description": "Extend CI with Custom Code Evals",
   "type": "module",
   "types": "./dist/index.d.ts",
   "main": "dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 
+import { CLI_TAGLINE } from './constants.js';
 import { MandolineCI } from './core.js';
 import { formatCliResults } from './formatters/cliResults.js';
 import { resolveGitReferences } from './git.js';
@@ -24,9 +25,7 @@ const program = new Command();
 
 program
   .name('mandoline-ci')
-  .description(
-    'Code evaluation tool that extends CI pipelines to assess intent and quality expectations'
-  )
+  .description(CLI_TAGLINE)
   .version(getPackageVersion(import.meta.url));
 
 program

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const DEFAULT_THRESHOLD = -0.333;
 export const DEFAULT_BASE_BRANCH = 'main';
 export const DEFAULT_HEAD_BRANCH = 'HEAD';
 export const DEFAULT_SCORE_OBJECTIVE = 'maximize';
+export const CLI_TAGLINE = 'Extend CI with Custom Code Evals';
 
 // Git's empty tree hash - used for comparing against initial commits or shallow clones
 export const EMPTY_TREE_HASH = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';


### PR DESCRIPTION
## Summary
- centralize the CLI tagline in constants and reuse it for commander help output
- update package metadata and README intro to match the new messaging

## Testing
- npm test -- --watchman=false